### PR TITLE
Changes backslashes to forward slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,32 @@ Please make sure that you have appropriate runtimes, modules, packages and most 
  
 ## EventPushListener
 
-- REST and JSON Event Push Subscriber [README](EventPushListener\RestAndJsonEventPushSubscriber\RestAndJsonEventPushSubscriber\ReadMe.md)
-- [Enumerated event types](EventPushListener\RestAndJsonEventPushSubscriber\RestAndJsonEventPushSubscriber\Models\EventType.cs) to subscribe to
-- [Startup and Hello Word](EventPushListener\RestAndJsonEventPushSubscriber\RestAndJsonEventPushSubscriber\Startup.cs) response
+- REST and JSON Event Push Subscriber [README](EventPushListener/RestAndJsonEventPushSubscriber/RestAndJsonEventPushSubscriber/ReadMe.md)
+- [Enumerated event types](EventPushListener/RestAndJsonEventPushSubscriber/RestAndJsonEventPushSubscriber/Models/EventType.cs) to subscribe to
+- [Startup and Hello Word](EventPushListener/RestAndJsonEventPushSubscriber/RestAndJsonEventPushSubscriber/Startup.cs) response
 
 ## GatewayAPI
 
-- [C# implementation](<GatewayAPI\DotNet\GettingStarted\Sertifi C%23 Code Sample.cs>) 
-- [Java implementation 1](GatewayAPI\Java\Code_Sample_1\JavaSample.java)
-- [Java implementation 2](GatewayAPI\Java\Code_Sample_2\Main.java)
-- [PHP implementation](<GatewayAPI\PHP\GettingStarted\Sertifi php Example.php>)
+- [C# implementation](<GatewayAPI/DotNet/GettingStarted/Sertifi C%23 Code Sample.cs>) 
+- [Java implementation 1](GatewayAPI/Java/Code_Sample_1/JavaSample.java)
+- [Java implementation 2](GatewayAPI/Java/Code_Sample_2/Main.java)
+- [PHP implementation](<GatewayAPI/PHP/GettingStarted/Sertifi php Example.php>)
 
 ## Rest API
 
-- [README](<Rest API\README.md>)
+- [README](<Rest API/README.md>)
 
 ## Salesforce
 
-- [Extend Update Notifications README](<Salesforce\ExtendUpdateNotificationsSample\README.md>)
+- [Extend Update Notifications README](<Salesforce/ExtendUpdateNotificationsSample/README.md>)
 - [One Pass Apex sample overview README](<Salesforce/OnePassApexSample/README.md>)
-- [Apex snippets for creating objects for sending and api call for sending signatures README](<Salesforce\OnePassApexSample\OneCallCreateObjects\README.md>)
+- [Apex snippets for creating objects for sending and api call for sending signatures README](<Salesforce/OnePassApexSample/OneCallCreateObjects/README.md>)
 - [Snippets overview for building via parameters README](<Salesforce/OnePassApexSample/README.md>)
-- [Visualforce Page and controller how to README](<Salesforce\OnePassApexSample\OneCallCreateObjectsAndGetLink\README.md>)
-- [One Pass sample C#](<Salesforce\OnePassDotNetSample\Program.cs>)
-- [Esign for Salesforce API send eContract via Apex trigger README](<Salesforce\OnePassTriggerSample\Readme.md>)
-- [SendZQuotes Button README](<Salesforce\SendZQuotesFromOppSample\README.md>)
-- [Sertifi API samples](<Salesforce\SertifiSFAPISamples\GetLinkSample.txt>)
+- [Visualforce Page and controller how to README](<Salesforce/OnePassApexSample/OneCallCreateObjectsAndGetLink/README.md>)
+- [One Pass sample C#](<Salesforce/OnePassDotNetSample/Program.cs>)
+- [Esign for Salesforce API send eContract via Apex trigger README](<Salesforce/OnePassTriggerSample/Readme.md>)
+- [SendZQuotes Button README](<Salesforce/SendZQuotesFromOppSample/README.md>)
+- [Sertifi API samples](<Salesforce/SertifiSFAPISamples/GetLinkSample.txt>)
 
 ### License
 


### PR DESCRIPTION
This PR resolves readme links by changing backslashes to forward slashes, which should make them work across platforms.